### PR TITLE
Added cache control for 301s that don't specify TTL.

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -92,6 +92,10 @@ sub vcl_backend_response {
             return(retry);
         }
     }
+
+    if (beresp.status == 301 && ((beresp.http.cache-control !~ "s-maxage") || (beresp.http.cache-control !~ "max-age"))){
+        set beresp.ttl = 31536000s;
+    }
 }
 
 sub vcl_deliver {


### PR DESCRIPTION
Set it so that varnish caches it locally for one year.