### PR TITLE
added request limit for internalcontent-preview

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -49,7 +49,7 @@ sub vcl_recv {
         set req.http.X-VarnishPassThrough = "true";
     }
 
-    if (req.url ~ "^\/content-preview.*$") {
+    if ((req.url ~ "^\/content-preview.*$") || (req.url ~ "^\/internalcontent-preview.*$")) {
         if (vsthrottle.is_denied(client.identity, 2, 1s)) {
     	    # Client has exceeded 2 reqs per 1s
     	    return (synth(429, "Too Many Requests"));


### PR DESCRIPTION
https status code 429 (too many requests) should take place in case we exeed 2 requests per second to internalcontent-preview