### PR TITLE
Returning pass on notifications-push endpoints, 

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -54,10 +54,6 @@ sub vcl_recv {
     	    # Client has exceeded 2 reqs per 1s
     	    return (synth(429, "Too Many Requests"));
         }
-    } elseif (req.url ~ "^\/content\/notifications-push.*$") {
-        set req.backend_hint = content_notifications_push;
-    } elseif (req.url ~ "^\/lists\/notifications-push.*$") {
-        set req.backend_hint = list_notifications_push;
         # Routing preset here as vulcan is unable to route on query strings
     } elseif (req.url ~ "\/content\?.*isAnnotatedBy=.*") {
         set req.http.Host = "public-content-by-concept-api";
@@ -81,6 +77,13 @@ sub vcl_recv {
       }
     }
     unset req.http.Authorization;
+    if (req.url ~ "^\/content\/notifications-push.*$") {
+        set req.backend_hint = content_notifications_push;
+        return (pass);
+    } elseif (req.url ~ "^\/lists\/notifications-push.*$") {
+        set req.backend_hint = list_notifications_push;
+        return (pass);
+    }
 }
 
 sub vcl_synth {

--- a/default.vcl
+++ b/default.vcl
@@ -79,10 +79,10 @@ sub vcl_recv {
     unset req.http.Authorization;
     if (req.url ~ "^\/content\/notifications-push.*$") {
         set req.backend_hint = content_notifications_push;
-        return (pass);
+        return (pipe);
     } elseif (req.url ~ "^\/lists\/notifications-push.*$") {
         set req.backend_hint = list_notifications_push;
-        return (pass);
+        return (pipe);
     }
 }
 

--- a/default.vcl
+++ b/default.vcl
@@ -126,3 +126,9 @@ sub vcl_deliver {
         set resp.http.X-Cache = "MISS";
     }
 }
+
+sub vcl_pipe {
+    # http://www.varnish-cache.org/ticket/451
+    # This forces every pipe request to be the first one.
+    set bereq.http.connection = "close";
+}

--- a/default.vcl
+++ b/default.vcl
@@ -54,7 +54,7 @@ sub vcl_recv {
     	    # Client has exceeded 2 reqs per 1s
     	    return (synth(429, "Too Many Requests"));
         }
-        # Routing preset here as vulcan is unable to route on query strings
+    # Routing preset here as vulcan is unable to route on query strings
     } elseif (req.url ~ "\/content\?.*isAnnotatedBy=.*") {
         set req.http.Host = "public-content-by-concept-api";
     } elseif (req.url ~ "\/concept\/search.*$") {


### PR DESCRIPTION
Meaning not to cache their requests. This might help closing the requests, which is currently a problem.