### PR TITLE
Apply same logic to /__agghealth as /__health

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -68,7 +68,7 @@ sub vcl_recv {
         set req.http.X-Original-Request-URL = "https://" + req.http.Host + req.url;
     }
 
-    if ((req.url ~ "^\/__health.*$") || (req.url ~ "^\/__gtg.*$")) {
+    if ((req.url ~ "^\/__health.*$") || (req.url ~ "^\/__agghealth.*$") || (req.url ~ "^\/__gtg.*$")) {
         set req.http.Host = "aggregate-healthcheck";
         return (pass);
     } elseif ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {


### PR DESCRIPTION
See https://github.com/Financial-Times/aggregate-healthcheck/pull/26 for new endpoint

Only applies to aggregate-healthcheck, not other apps with a healthcheck