### PR TITLE
Add CORS headers for smartlogic widget

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -202,4 +202,16 @@ sub vcl_deliver {
     } else {
         set resp.http.X-Cache = "MISS";
     }
+
+    # CORS response for smartlogic widget
+    if (req.http.Origin == "https://cloud.smartlogic.com") {
+        set resp.http.Access-Control-Allow-Origin = req.http.Origin;
+        set resp.http.Access-Control-Allow-Methods = "GET, POST, OPTIONS";
+        set resp.http.Access-Control-Allow-Headers = "*";
+    }
+    if (resp.http.Vary) {
+        set resp.http.Vary = resp.http.Vary + ",Origin";
+    } else {
+        set resp.http.Vary = "Origin";
+    }
 }

--- a/default.vcl
+++ b/default.vcl
@@ -204,7 +204,7 @@ sub vcl_deliver {
     }
 
     # CORS response for smartlogic widget
-    if (req.http.Origin == "https://cloud.smartlogic.com" && req.url ~ "(\/content|\/concept\/search|\/concordances)") {
+    if (req.http.Origin == "https://cloud.smartlogic.com" && req.url ~ "(\/content.*|\/concept\/search.*|\/concordances.*)") {
         set resp.http.Access-Control-Allow-Origin = req.http.Origin;
         set resp.http.Access-Control-Allow-Methods = "GET, POST, OPTIONS";
         set resp.http.Access-Control-Allow-Headers = "*";

--- a/default.vcl
+++ b/default.vcl
@@ -204,7 +204,7 @@ sub vcl_deliver {
     }
 
     # CORS response for smartlogic widget
-    if (req.http.Origin == "https://cloud.smartlogic.com") {
+    if (req.http.Origin == "https://cloud.smartlogic.com" && req.url ~ "(\/content|\/concept\/search|\/concordances)") {
         set resp.http.Access-Control-Allow-Origin = req.http.Origin;
         set resp.http.Access-Control-Allow-Methods = "GET, POST, OPTIONS";
         set resp.http.Access-Control-Allow-Headers = "*";


### PR DESCRIPTION
This change will add cors related response headers when varnish gets an access from smartlogic and request has an `Origin` header. APIs which widget requires are `public-content-by-concept-api`, `concept-search-api`, `public-concordances-api`, `content/:uuid`. Hopefully all those APIs is behind this varnish layer but I don't know how to test it, sorry.

Tickets
https://trello.com/c/15ZZuKjf/89-investigate-smartlogic-side-panel-widgets
https://trello.com/c/F8WJapQ0/150-implement-widgets-in-smartlogic-side-panel