### PR TITLE
Upgrade elb registrator and remove AWS props from it's config

### DIFF
--- a/helm/delivery-varnish/templates/elb-registrator-job.yaml
+++ b/helm/delivery-varnish/templates/elb-registrator-job.yaml
@@ -27,21 +27,6 @@ spec:
             configMapKeyRef:
               name: global-config
               key: dns_subdomain
-        - name: AWS_REGION
-          valueFrom:
-            configMapKeyRef:
-              name: global-config
-              key: aws.region
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: global-secrets
-              key: aws.access_key_id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: global-secrets
-              key: aws.secret_access_key
         - name: KONSTRUCTOR_API_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/delivery-varnish/values.yaml
+++ b/helm/delivery-varnish/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: coco/delivery-varnish
   pullPolicy: IfNotPresent
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.0.0"
+  image: "coco/coco-elb-dns-registrator:5.0.1"
 #resources:
 #  limits:
 #    memory: 256Mi


### PR DESCRIPTION
- see https://github.com/Financial-Times/coco-elb-dns-registrator/pull/11
- tested in dev - deleted `upp-k8s-dev-delivery-eu.ft.com` CNAME and the elb registrator 5.0.1 re-created it
