### PR TITLE
Add dns_zone var to the elb-dns-registrator jobs

### DIFF
--- a/helm/delivery-varnish/templates/elb-registrator-job.yaml
+++ b/helm/delivery-varnish/templates/elb-registrator-job.yaml
@@ -27,6 +27,11 @@ spec:
             configMapKeyRef:
               name: global-config
               key: dns_subdomain
+        - name: DomainZone
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: dns_zone
         - name: KONSTRUCTOR_API_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/delivery-varnish/values.yaml
+++ b/helm/delivery-varnish/values.yaml
@@ -11,9 +11,8 @@ image:
   repository: coco/delivery-varnish
   pullPolicy: IfNotPresent
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.0.1"
+  image: "coco/coco-elb-dns-registrator:5.1.0"
 #resources:
 #  limits:
 #    memory: 256Mi
-
 


### PR DESCRIPTION
As part of the DNS migration we need to be able to configure the DNS zone provided to the Konstructor API. With this change upgrade the coco/coco-elb-dns-registrator version to 5.1.0. This version support the DomainZone parameter. Also, we add the DomainZone value to be taken from the global-config configmap dns_zone key.

This change depends on Financial-Times/upp-global-configs#89