### PR TITLE
Change dev delivery-varnish LB cert

### DIFF
--- a/helm/delivery-varnish/app-configs/delivery-varnish_delivery.yaml
+++ b/helm/delivery-varnish/app-configs/delivery-varnish_delivery.yaml
@@ -2,7 +2,7 @@
 service:
   name: delivery-varnish
   # Apply the certificate from content test by default
-  certificateAwsArn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
+  certificateAwsArn: "arn:aws:acm:eu-west-1:070529446553:certificate/a6ab3d87-cdae-4db4-838f-3dbce570ad47"
 
 elb:
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"

--- a/helm/delivery-varnish/values.yaml
+++ b/helm/delivery-varnish/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: coco/delivery-varnish
   pullPolicy: IfNotPresent
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.1.0"
+  image: "coco/coco-elb-dns-registrator:5.1.1"
 #resources:
 #  limits:
 #    memory: 256Mi


### PR DESCRIPTION
As part of the migration to upp.ft.com a different certificate is required. This change sets the *.upp.ft.com certificate to be attached to the delivery-varnish LB of the clusters.