### PR TITLE
Add route53 LB reg job

### DIFF
--- a/helm/delivery-varnish/templates/elb-registrator-route53-job.yaml
+++ b/helm/delivery-varnish/templates/elb-registrator-route53-job.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Values.service.name }}-elb-registrator-route53-job-{{ .Release.Revision}}"
+  # This is what defines this resource as a hook. Without this line, the
+  # job is considered part of the release.
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  template:
+    metadata:
+      name: "{{ .Values.service.name }}-elb-registrator-route53"
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::345152836601:role/route53-iam-dnsonlyroleuppprodE94AAA36-CAPB27QPX3K8
+    spec:
+      # Keep trying to register in DNS until we manage to do it
+      restartPolicy: OnFailure
+      containers:
+      - name: "{{ .Values.service.name }}-elb-registrator-route53"
+        image: "{{ .Values.route53_elb_registrator.image }}"
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: certificates-storage
+        env:
+        - name: HOSTED_ZONE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: route53_hosted_zone_id
+        - name: DOMAINS
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: dns_subdomain
+        - name: DomainZone
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: dns_zone
+        - name: K8S_LB_SERVICE
+          value: "{{ .Values.service.name }}"
+      volumes:
+      - name: certificates-storage
+        hostPath:
+          path: /usr/share/ca-certificates

--- a/helm/delivery-varnish/values.yaml
+++ b/helm/delivery-varnish/values.yaml
@@ -16,3 +16,5 @@ elbRegistrator:
 #  limits:
 #    memory: 256Mi
 
+route53_elb_registrator:
+  image: "coco/upp-route53-elb-dns-registrator:1.0.1"


### PR DESCRIPTION
Add LB reg job that use the coco/upp-route53-elb-dns-registrator container to update/create records in Route53. This job duplicates the already existing elb reg job that update/create records in Dyn.