### PR TITLE
Remove deprecated live blog validators

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -101,11 +101,6 @@ backend upp_content_placeholder_validator {
   .port = "8080";
 }
 
-backend upp_live_blog_validator {
-  .host = "upp-live-blog-validator";
-  .port = "8080";
-}
-
 backend upp_live_blog_post_validator {
   .host = "upp-live-blog-post-validator";
   .port = "8080";
@@ -113,11 +108,6 @@ backend upp_live_blog_post_validator {
 
 backend upp_live_blog_package_validator {
   .host = "upp-live-blog-package-validator";
-  .port = "8080";
-}
-
-backend upp_internal_live_blog_validator {
-  .host = "upp-internal-live-blog-validator";
   .port = "8080";
 }
 
@@ -255,12 +245,6 @@ sub vcl_recv {
         } elseif (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-placeholder-internal\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_internal_content_placeholder_validator;
-        } elseif (req.http.Content-Type ~ "^application\/vnd\.ft-upp-live-blog\+json.*$") {
-            set req.url = "/validate";
-            set req.backend_hint = upp_live_blog_validator;
-        } elseif (req.http.Content-Type ~ "^application\/vnd\.ft-upp-live-blog-internal\+json.*$") {
-            set req.url = "/validate";
-            set req.backend_hint = upp_internal_live_blog_validator;
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-live-blog-post\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_live_blog_post_validator;


### PR DESCRIPTION
# Description

## What

Remove old live blog validators 

## Why

https://financialtimes.atlassian.net/browse/UPPSF-1655
Old validators are deprecated, live-blog-post-validator and live-blog-package-validator will be used from now on.

## Anything, in particular, you'd like to highlight to reviewers
--

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
