### PR TITLE
remove handling for /pages* routes

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -156,11 +156,6 @@ backend upp_schema_reader {
   .port = "8080";
 }
 
-backend public_pages_api {
-  .host = "public-pages-api";
-  .port = "8080";
-}
-
 sub vcl_init {
     # Instantiate sm1, sm2 for backends tile1, tile2
     # with 10 blacklisted objects as the threshold for marking the
@@ -313,8 +308,6 @@ sub vcl_recv {
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;
-    } elseif (req.url ~ "^\/pages.*$") {
-            set req.backend_hint = public_pages_api;
     }
 
     if (!basicauth.match("/etc/varnish/auth/.htpasswd",  req.http.Authorization)) {


### PR DESCRIPTION
# Description

Remove remove handling for /pages* routes

Handling for pages is moved to [k8s-path-routing-varnish](https://github.com/Financial-Times/k8s-path-routing-varnish/pull/38) for the sake of consistency between similarly working services.

# Why 

[Jira Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2741)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
