### PR TITLE
do not require basic auth on cm-portal menu links

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -227,7 +227,7 @@ sub vcl_recv {
     set req.url = regsub(req.url, "^\/+(.*)$","/\1");
 
     // Allow /ccf and /portal to pass without requiring auth. They have authentication of their own.
-    if ((req.url ~ "^\/ccf\/") || (req.url ~ "^\/portal\/$") || (req.url ~ "^\/portal\/specs\/") || (req.url ~ "^\/portal\/api\/") || (req.url ~ "^\/portal\/.+(\/|\.ico|\.css|\.html|\.js|\.js\.map|\.json|\.png|\.seq|\.sh|\.sq|\.txt|\.xml)$")) {
+    if ((req.url ~ "^\/ccf\/") || (req.url ~ "^\/portal\/$") || (req.url ~ "^\/portal\/specs\/") || (req.url ~ "^\/portal\/api\/") || (req.url ~ "^\/portal\/.+(\/|\.ico|\.css|\.html|\.js|\.js\.map|\.json|\.png|\.seq|\.sh|\.sq|\.txt|\.xml)$") || (req.url ~ "^\/portal\/(docs|concepts|swagger|query-builder)$")) {
         set req.backend_hint = internal_apps_routing_varnish;
         return (pipe);
     }


### PR DESCRIPTION
# Description

## What

Do not require basic auth on cm-portal menu links.
## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4207)

## Anything, in particular, you'd like to highlight to reviewers
This is a bug happening when reloading a page in the cm-portal (Except the Home page as it matches different condition in the vlc config)

The bug will still occur on staging and prod:
[CM  Portal Staging](https://cm-portal-test.in.ft.com/)
[CM Portal Prod](https://cm-portal.in.ft.com/)

The fix is deployed on dev and the bug shouldn't happen, you can test it:
[CM Portal Dev](https://cm-portal-dev.in.ft.com/)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
