### PR TITLE
Fix notifications push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:bionic as build
+FROM ubuntu:jammy as build
 
 WORKDIR /
 
 # install varnish 6.0-lts dependencies
 RUN apt-get update && \
     apt-get install -y curl gnupg2 && \
-    curl -L https://packagecloud.io/varnishcache/varnish62/gpgkey | apt-key add - && \
-    echo "deb https://packagecloud.io/varnishcache/varnish62/ubuntu/ bionic main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
+    curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
+    echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
     apt-get update && \
-    apt-get install -y libgetdns-dev varnish=6.2.1-1~bionic varnish-dev=6.2.1-1~bionic
+    apt-get install -y libgetdns-dev varnish=6.0.11-1~jammy varnish-dev=6.0.11-1~jammy
 
 # install varnish-modules
 RUN apt-get install -y git automake autoconf libtool python3 make docutils-common && \
-    git clone -b 6.2 https://github.com/varnish/varnish-modules.git && \
+    git clone -b 6.0-lts https://github.com/varnish/varnish-modules.git && \
     cd /varnish-modules && \
     ./bootstrap && \
     ./configure --prefix=/build && \
@@ -27,15 +27,15 @@ RUN  cd /vmod-basicauth && \
     make && \
     make install
 
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 # install varnish 6.0-lts dependencies
 RUN apt-get update && \
     apt-get install -y curl gnupg2 && \
-    curl -L https://packagecloud.io/varnishcache/varnish62/gpgkey | apt-key add - && \
-    echo "deb https://packagecloud.io/varnishcache/varnish62/ubuntu/ bionic main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
+    curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
+    echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
     apt-get update && \
-    apt-get install -y varnish=6.2.1-1~bionic
+    apt-get install -y varnish=6.0.11-1~jammy
 
 COPY --from=build /build/lib/varnish/vmods/ /usr/lib/varnish/vmods/
 COPY --from=build /build/share/ /usr/share/

--- a/default.vcl
+++ b/default.vcl
@@ -258,14 +258,17 @@ sub vcl_recv {
         return (pass);
     }
 
-    if (req.url ~ "^\/annotations\/notifications-push.*$") {
-        set req.backend_hint = annotation_notifications_push;
-	} elseif (req.url ~ "^\/pages\/notifications-push.*$") {
-        set req.backend_hint = page_notifications_push;
-    } elseif (req.url ~ "^\/lists\/notifications-push.*$") {
-        set req.backend_hint = list_notifications_push;
-    } elseif (req.url ~ "^\/content\/notifications-push.*$") {
-        set req.backend_hint = content_notifications_push;
+    if (req.url ~ "^\/(annotations|lists|pages|content)\/notifications-push.*$") {
+        if (req.url ~ "^\/annotations\/notifications-push.*$") {
+            set req.backend_hint = annotation_notifications_push;
+	    } elseif (req.url ~ "^\/pages\/notifications-push.*$") {
+            set req.backend_hint = page_notifications_push;
+        } elseif (req.url ~ "^\/lists\/notifications-push.*$") {
+            set req.backend_hint = list_notifications_push;
+        } elseif (req.url ~ "^\/content\/notifications-push.*$") {
+            set req.backend_hint = content_notifications_push;
+        }
+        return (pipe);
     } elseif (req.url ~ "\/content\?.*isAnnotatedBy=.*") {
         set req.backend_hint = public_content_by_concept_api;
     } elseif (req.url ~ "\/concept\/search.*$") {


### PR DESCRIPTION
# Description

## What

- Upgrade base image to ubuntu 22.04 (again)
- Switch to varnish 6.0 LTS (again)
- Change how requests to notifications-push are handled.

## Why

The base image upgrade is performed because the old image was out of support.

The changes to the VCL for notifications-push were done, because previous solution was depending on a bug in varnish, where `send_timeout` was not honoured for http/1.0 requests.  
This bug was fixed in varnish 6.4. And the fix is present in the 6.0lts. 

## Anything, in particular, you'd like to highlight to reviewers



## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
