### PR TITLE
Fix routing for /query/latest endpoint

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -355,12 +355,13 @@ sub vcl_recv {
         set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
         set req.backend_hint = cm_concept_lists_api;
     } elseif (req.url ~ "^\/content\/query\/latest.*$") {
-    // More specific condition first
-        set req.url = "/search/latest";
+        set req.url = regsub(req.url, "^\/content\/query\/latest(.*)$", "/search/latest\1");
         set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/content\/query.*$") {
-    // More general condition after
+    } elseif (req.url ~ "^\/content\/query\/?$") {
         set req.url = "/search";
+        set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query\/(.*)$") {
+        set req.url = regsub(req.url, "^\/content\/query\/(.*)$", "/search/\1");
         set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,11 +354,11 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif (req.url ~ "^\/content\/query.*$") {
-            set req.url = "/search";
-            set req.backend_hint = cm_search_api;
-    } elif (req.url ~ "^\/relatedcontent\/.*$") {
-            set req.backend_hint = public_content_relation_api;
+    } elif(req.url ~ "^\/content\/query.*$") {
+        set req.url = "/search";
+        set req.backend_hint = cm_search_api;
+    } elif(req.url ~ "^\/relatedcontent\/.*$") {
+        set req.backend_hint = public_content_relation_api;
     }
 
     if (!basicauth.match("/etc/varnish/auth/.htpasswd",  req.http.Authorization)) {

--- a/default.vcl
+++ b/default.vcl
@@ -354,8 +354,8 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query\/?(.*)$") {
-        set req.url = regsub(req.url, "^\/content\/query\/?(.*)$", "/search/\1");
+    } elseif (req.url ~ "^\/content\/query(\/.*)?$") {
+        set req.url = regsub(req.url, "^\/content\/query(\/.*)?$", "/search\1");
         set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -347,20 +347,22 @@ sub vcl_recv {
             set req.backend_hint = upp_live_event_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
-            set req.backend_hint = upp_schema_reader;
+        set req.backend_hint = upp_schema_reader;
     } elseif (req.url ~ "^\/metadata-quality.*$") {
-            set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
-            set req.backend_hint = cm_metadata_quality_api;
-    } else if (req.url ~ "^\/concept\/lists.*$") {
-            set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
-            set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^\/content\/query\/latest.*$") {
+        set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
+        set req.backend_hint = cm_metadata_quality_api;
+    } elseif (req.url ~ "^\/concept\/lists.*$") {
+        set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
+        set req.backend_hint = cm_concept_lists_api;
+    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
+    // More specific condition first
         set req.url = "/search/latest";
         set req.backend_hint = cm_search_api;
-    } elif(req.url ~ "^\/content\/query.*$") {
+    } elseif (req.url ~ "^\/content\/query.*$") {
+    // More general condition after
         set req.url = "/search";
         set req.backend_hint = cm_search_api;
-    } elif(req.url ~ "^\/relatedcontent\/.*$") {
+    } elseif (req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }
 

--- a/default.vcl
+++ b/default.vcl
@@ -354,8 +354,8 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query.*$") {
-            set req.url = regsub(req.url, "^\/content\/query(.*)$", "/search\1");
+    } elseif (req.url ~ "^\/content\/query\/?") {
+            set req.url = regsub(req.url, "^\/content\/query\/?", "/search\/");
             set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -351,18 +351,17 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/metadata-quality.*$") {
             set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
             set req.backend_hint = cm_metadata_quality_api;
-    } else if (req.url ~ "^\/concept\/lists.*$") {
+    } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } else if (req.url ~ "^\/content\/query\/latest.*$") {
-          set req.url = "/search/latest";
-          set req.backend_hint = cm_search_api;
-    }
-    else if (req.url ~ "^\/content\/query.*$") {
-          set req.url = "/search";
-          set req.backend_hint = cm_search_api;
-    } elif(req.url ~ "^\/relatedcontent\/.*$") {
-        set req.backend_hint = public_content_relation_api;
+    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
+            set req.url = "/search/latest";
+            set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query.*$") {
+            set req.url = "/search";
+            set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/relatedcontent\/.*$") {
+            set req.backend_hint = public_content_relation_api;
     }
 
     if (!basicauth.match("/etc/varnish/auth/.htpasswd",  req.http.Authorization)) {

--- a/default.vcl
+++ b/default.vcl
@@ -355,7 +355,7 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif(req.url ~ "^.*\/content\/query(.*)$") {
-          set req.url = regsub(req.url, "^\/search\/(.*)$", "/\1");
+          set req.url = regsub(req.url, "^\/content\/query(.*)$", "/search\1");
           set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -347,17 +347,17 @@ sub vcl_recv {
             set req.backend_hint = upp_live_event_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
-        set req.backend_hint = upp_schema_reader;
+            set req.backend_hint = upp_schema_reader;
     } elseif (req.url ~ "^\/metadata-quality.*$") {
-        set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
-        set req.backend_hint = cm_metadata_quality_api;
-    } elseif (req.url ~ "^\/concept\/lists.*$") {
-        set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
-        set req.backend_hint = cm_concept_lists_api;
+            set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
+            set req.backend_hint = cm_metadata_quality_api;
+    } else if (req.url ~ "^\/concept\/lists.*$") {
+            set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
+            set req.backend_hint = cm_concept_lists_api;
     } elseif (req.url ~ "^\/content\/query") {
           set req.url = "/search" + regsub(req.url, "^\/content\/query", "");
           set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/relatedcontent\/.*$") {
+    } elif (req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }
 

--- a/default.vcl
+++ b/default.vcl
@@ -354,8 +354,8 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif (req.url ~ "^\/content\/query") {
-          set req.url = "/search" + regsub(req.url, "^\/content\/query", "");
+    } elif(req.url ~ "^.*\/content\/query(.*)$") {
+          set req.url = regsub(req.url, "^\/search\/(.*)$", "/\1");
           set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -351,16 +351,13 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/metadata-quality.*$") {
             set req.url = regsub(req.url, "^\/metadata-quality\/(.*)$", "/\1");
             set req.backend_hint = cm_metadata_quality_api;
-    } elseif (req.url ~ "^\/concept\/lists.*$") {
+    } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
-            set req.url = "/search/latest";
+    } elif (req.url ~ "^\/content\/query.*$") {
+            set req.url = "/search";
             set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/content\/query.*$") {
-            set req.url = regsub(req.url, "^\/content\/query(\/.*)?$", "/search\1");
-            set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/relatedcontent\/.*$") {
+    } elif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;
     }
 

--- a/default.vcl
+++ b/default.vcl
@@ -354,9 +354,9 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query\/?") {
-            set req.url = regsub(req.url, "^\/content\/query\/?", "/search\/");
-            set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query\/?(.*)$") {
+        set req.url = regsub(req.url, "^\/content\/query\/?(.*)$", "/search/\1");
+        set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;
     }

--- a/default.vcl
+++ b/default.vcl
@@ -354,15 +354,9 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
         set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
         set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
-        set req.url = regsub(req.url, "^\/content\/query\/latest(.*)$", "/search/latest\1");
-        set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/content\/query\/?$") {
-        set req.url = "/search";
-        set req.backend_hint = cm_search_api;
-    } elseif (req.url ~ "^\/content\/query\/(.*)$") {
-        set req.url = regsub(req.url, "^\/content\/query\/(.*)$", "/search/\1");
-        set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query") {
+          set req.url = "/search" + regsub(req.url, "^\/content\/query", "");
+          set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }

--- a/default.vcl
+++ b/default.vcl
@@ -354,9 +354,12 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query(\/.*)?$") {
-        set req.url = regsub(req.url, "^\/content\/query(\/.*)?$", "/search\1");
-        set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
+            set req.url = "/search/latest";
+            set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query.*$") {
+            set req.url = regsub(req.url, "^\/content\/query(\/.*)?$", "/search\1");
+            set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;
     }

--- a/default.vcl
+++ b/default.vcl
@@ -354,6 +354,9 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
+    } elif(req.url ~ "^\/content\/query\/latest.*$") {
+        set req.url = "/search/latest";
+        set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/content\/query.*$") {
         set req.url = "/search";
         set req.backend_hint = cm_search_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,9 +354,13 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = "/search";
-        set req.backend_hint = cm_search_api;
+    } else if (req.url ~ "^\/content\/query\/latest.*$") {
+          set req.url = "/search/latest";
+          set req.backend_hint = cm_search_api;
+    }
+    else if (req.url ~ "^\/content\/query.*$") {
+          set req.url = "/search";
+          set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }

--- a/default.vcl
+++ b/default.vcl
@@ -354,9 +354,12 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^.*\/content\/query(.*)$") {
-          set req.url = regsub(req.url, "^\/content\/query(.*)$", "/search\1");
-          set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
+            set req.url = regsub(req.url, "^\/content\/query\/latest", "/search/latest");
+            set req.backend_hint = cm_search_api;
+    } elseif (req.url ~ "^\/content\/query.*$") {
+            set req.url = regsub(req.url, "^\/content\/query", "/search");
+            set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }

--- a/default.vcl
+++ b/default.vcl
@@ -354,10 +354,10 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query") {
+    } elif (req.url ~ "^\/content\/query") {
           set req.url = "/search" + regsub(req.url, "^\/content\/query", "");
           set req.backend_hint = cm_search_api;
-    } elif (req.url ~ "^\/relatedcontent\/.*$") {
+    } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;
     }
 

--- a/default.vcl
+++ b/default.vcl
@@ -355,10 +355,10 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elseif (req.url ~ "^\/content\/query\/latest.*$") {
-            set req.url = "/search/latest";
+            set req.url = regsub(req.url, "^\/content\/query\/latest", "/search/latest");
             set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/content\/query.*$") {
-            set req.url = "/search";
+            set req.url = regsub(req.url, "^\/content\/query", "/search");
             set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,11 +354,8 @@ sub vcl_recv {
     } elseif (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elseif (req.url ~ "^\/content\/query\/latest.*$") {
-            set req.url = regsub(req.url, "^\/content\/query\/latest", "/search/latest");
-            set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/content\/query.*$") {
-            set req.url = regsub(req.url, "^\/content\/query", "/search");
+            set req.url = regsub(req.url, "^\/content\/query(.*)$", "/search\1");
             set req.backend_hint = cm_search_api;
     } elseif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;


### PR DESCRIPTION
# Description

## What

Delivery varnish routes requests only to “/search“, subsequent parts for the url are ignored. This means that requests like “[https://api.ft.com/query/latest“](https://api.ft.com/query/latest%E2%80%9C) are routed to “…./search“ instead of “…/search/latest”.
Delivery varnish [line](https://github.com/Financial-Times/delivery-varnish/blob/9d9f5a1fa22d082cc79d10795e6f8556e5f9b586/default.vcl#L357).

## Why

JIRA -> https://financialtimes.atlassian.net/browse/UPPSF-5008

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
