### PR TITLE
Fix routing for cm-search-api to route properly to /search and /search/latest

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -358,7 +358,7 @@ sub vcl_recv {
         set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = "/search"
+        set req.url = "/search";
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,8 +354,11 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^\/content\/query.*$") {
+    } elif(req.url ~ "^\/content\/query\/latest.*$") {
         set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
+        set req.backend_hint = cm_search_api;
+    } elif(req.url ~ "^\/content\/query.*$") {
+        set req.url = "/search"
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,11 +354,14 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^\/content\/query\/latest.*$") {
-        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
-        set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = "/search";
+        set extracted_group_value = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "/\1");
+
+        if (strlen(extracted_group) > 0) {
+        	set req.url = "/search/" + extracted_group_value;
+        } else {
+        	set req.url = "/search";
+        }
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,7 +354,7 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif (req.url ~ "^\/content\/query\/content\/query\/latest.*$") {
+    } elif (req.url ~ "^\/content\/query\/latest.*$") {
             set req.url = "/search/latest";
             set req.backend_hint = cm_search_api;
     } elif (req.url ~ "^\/content\/query.*$") {

--- a/default.vcl
+++ b/default.vcl
@@ -355,10 +355,10 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif (req.url ~ "^\/content\/query\/latest.*$") {
-            set req.url = "/search/latest";
+            set req.url = "/query/latest";
             set req.backend_hint = cm_search_api;
     } elif (req.url ~ "^\/content\/query.*$") {
-            set req.url = "/search";
+            set req.url = "/query";
             set req.backend_hint = cm_search_api;
     } elif (req.url ~ "^\/relatedcontent\/.*$") {
             set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,11 +354,14 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
-        set req.backend_hint = cm_search_api;
-    } elif(req.url ~ "^\/relatedcontent\/.*$") {
-        set req.backend_hint = public_content_relation_api;
+    } elif (req.url ~ "^\/content\/query\/latest.*$") {
+            set req.url = "/search/latest";
+            set req.backend_hint = cm_search_api;
+    } elif (req.url ~ "^\/content\/query.*$") {
+            set req.url = "/search";
+            set req.backend_hint = cm_search_api;
+    } elif (req.url ~ "^\/relatedcontent\/.*$") {
+            set req.backend_hint = public_content_relation_api;
     }
 
     if (!basicauth.match("/etc/varnish/auth/.htpasswd",  req.http.Authorization)) {

--- a/default.vcl
+++ b/default.vcl
@@ -355,7 +355,7 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = "/search";
+        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1")
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -355,15 +355,7 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif(req.url ~ "^\/content\/query.*$") {
-        # Declare the variable at the top level
-        declare local var extracted_group_value;
-        set extracted_group_value = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "/\1");
-
-        if (strlen(extracted_group) > 0) {
-        	set req.url = "/search/" + extracted_group_value;
-        } else {
-        	set req.url = "/search";
-        }
+        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;

--- a/default.vcl
+++ b/default.vcl
@@ -354,7 +354,7 @@ sub vcl_recv {
     } else if (req.url ~ "^\/concept\/lists.*$") {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
-    } elif (req.url ~ "^\/content\/query\/latest.*$") {
+    } elif (req.url ~ "^\/content\/query\/content\/query\/latest.*$") {
             set req.url = "/search/latest";
             set req.backend_hint = cm_search_api;
     } elif (req.url ~ "^\/content\/query.*$") {

--- a/default.vcl
+++ b/default.vcl
@@ -355,6 +355,8 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif(req.url ~ "^\/content\/query.*$") {
+        # Declare the variable at the top level
+        declare local var extracted_group_value;
         set extracted_group_value = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "/\1");
 
         if (strlen(extracted_group) > 0) {

--- a/default.vcl
+++ b/default.vcl
@@ -355,7 +355,7 @@ sub vcl_recv {
             set req.url = regsub(req.url, "^\/concept\/lists\/(.*)$", "/\1");
             set req.backend_hint = cm_concept_lists_api;
     } elif(req.url ~ "^\/content\/query.*$") {
-        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1")
+        set req.url = regsub(req.url, "^\/content\/query\/content\/query\/(.*)$", "\/search/\1");
         set req.backend_hint = cm_search_api;
     } elif(req.url ~ "^\/relatedcontent\/.*$") {
         set req.backend_hint = public_content_relation_api;


### PR DESCRIPTION
# Description

**Please, check the JIRA ticket since there are an important details there :)**

The routing for /search/latest has to be fixed since now forwards /latest requests to the basic /search endpoint.
## What

The vcl config has to be updated in order to route the requests correctly. 

## Why

JIRA -> https://financialtimes.atlassian.net/browse/UPPSF-5008

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
