### PR TITLE
Fix/uppsf 5559 add missing validators to our varnish config and the public validate endpoint

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -181,6 +181,11 @@ backend upp_internal_content_package_validator {
   .port = "8080";
 }
 
+backend upp_content_relation_validator {
+  .host = "upp-content-relation-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -386,6 +391,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-package-internal\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_internal_content_package_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-relation\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_content_relation_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;

--- a/default.vcl
+++ b/default.vcl
@@ -166,6 +166,11 @@ backend upp_clip_set_validator {
   .port = "8080";
 }
 
+backend upp_clip_validator {
+  .host = "upp-clip-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -362,6 +367,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-clip-set\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_clip_set_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-clip\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_clip_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;

--- a/default.vcl
+++ b/default.vcl
@@ -186,6 +186,11 @@ backend upp_content_relation_validator {
   .port = "8080";
 }
 
+backend upp_custom_code_component_validator {
+  .host = "upp-custom-code-component-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -394,6 +399,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-relation\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_content_relation_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-custom-code-component\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_custom_code_component_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;

--- a/default.vcl
+++ b/default.vcl
@@ -161,6 +161,11 @@ backend upp_live_event_validator {
   .port = "8080";
 }
 
+backend upp_clip_set_validator {
+  .host = "upp-clip-set-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -354,6 +359,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-live-event\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_live_event_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-clip-set\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_clip_set_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;

--- a/default.vcl
+++ b/default.vcl
@@ -176,6 +176,11 @@ backend upp_content_package_validator {
   .port = "8080";
 }
 
+backend upp_internal_content_package_validator {
+  .host = "upp-internal-content-package-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -378,6 +383,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-package\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_content_package_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-package-internal\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_internal_content_package_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;

--- a/default.vcl
+++ b/default.vcl
@@ -171,6 +171,11 @@ backend upp_clip_validator {
   .port = "8080";
 }
 
+backend upp_content_package_validator {
+  .host = "upp-content-package-validator";
+  .port = "8080";
+}
+
 backend upp_schema_reader {
   .host = "upp-schema-reader";
   .port = "8080";
@@ -370,6 +375,9 @@ sub vcl_recv {
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-clip\+json.*$") {
             set req.url = "/validate";
             set req.backend_hint = upp_clip_validator;
+        } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-content-package\+json.*$") {
+            set req.url = "/validate";
+            set req.backend_hint = upp_content_package_validator;
         }
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;


### PR DESCRIPTION
# Description

## What

This pull request adds configuration that enables requests to several of our validators from the public validation endpoint.

The validators included are:

- upp-clip-set-validator
- upp-clip-validator
- upp-content-package-validator
- upp-internal-content-package-validator
- upp-content-relation-validator
- upp-custom-code-component-validator

Without the configuration provided by this PR, requests made to the /content/validate endpoint fail when the content types being validated are associated with any of the validators listed above.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5559)

## Anything, in particular, you'd like to highlight to reviewers

When reviewing, check for minor mistakes related to spelling and the various references to validators, Varnish backends, etc.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)