### PR TITLE
[UPPSF-6071] Add redirect rule for enriched-content-read-postgres

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -236,6 +236,11 @@ backend concept_suggestions_api {
   .port = "8080";
 }
 
+backend enriched_content_read_postgres {
+  .host = "enriched-content-read-postgres";
+  .port = "8080";
+}
+
 backend cm_content_tree_api {
   .host = "cm-content-tree-api";
   .port = "8080";
@@ -445,6 +450,9 @@ sub vcl_recv {
             set req.backend_hint = public_content_relation_api;
     } elif (req.url ~ "^\/ontotext\/suggestions\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/details.*$") {
             set req.backend_hint = concept_suggestions_api;
+    } elif (req.url ~ "^\/content\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal.*$") {
+            set req.url = regsub(req.url, "^/content/(.*)$", "/\1");
+            set req.backend_hint = enriched_content_read_postgres;
     } elseif (req.url ~ "\/content-tree\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*$") {
             set req.backend_hint = cm_content_tree_api;
     }


### PR DESCRIPTION
# Description

## What

This change is adding a redirect rule to our Varnish configuration for the newly created service `enriched-content-read-postgres`.
The intention is to redirect calls to `/content/{uuid}/internal` to the new service, by sending only the `{uuid}/internal` path.

## Why

Ticket: https://financialtimes.atlassian.net/browse/UPPSF-6071

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
