### PR TITLE
Feature UPPSF-6842 Add core_search_api backend and update vcl_recv for search URL handling

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -206,6 +206,11 @@ backend upp_schema_reader {
   .port = "8080";
 }
 
+backend core_search_api {
+  .host = "core-search-api";
+  .port = "8080";
+}
+
 backend cm_metadata_quality_api {
   .host = "cm-metadata-quality-api";
   .port = "8080";
@@ -432,9 +437,12 @@ sub vcl_recv {
             set req.url = "/validate";
             set req.backend_hint = upp_custom_code_component_validator;
         } else if (req.http.Content-Type ~ "^application\/vnd\.ft-upp-custom-code-component-internal\+json.*$") {
-	    set req.url = "/validate";
+	        set req.url = "/validate";
             set req.backend_hint = upp_internal_custom_code_component_validator;
-	}
+	    }
+    } elseif (req.url ~ "^\/search.*$") {
+        set req.url = regsub(req.url, "^\/search\/(.*)$", "/\1");
+        set req.backend_hint = core_search_api;
     } elseif (req.url ~ "^\/schemas.*$") {
             set req.backend_hint = upp_schema_reader;
     } elseif (req.url ~ "^\/metadata-quality.*$") {


### PR DESCRIPTION
# Description

## What

This PR adds routing for `core-search-api` in Varnish.

Changes made:
- Added a new backend definition: `core_search_api` (`core-search-api:8080`).
- Added URL handling in `vcl_recv` for `/search...` requests.
- Rewrites incoming URLs by stripping the `/search/` prefix before forwarding to the `core_search_api` backend.

## Why

This change adds `core-search-api` to the Varnish configuration so it can be used as a backend in delivery-varnish routing.

Ticket: [UPPSF-6842](https://financialtimes.atlassian.net/browse/UPPSF-6842)

## Anything, in particular, you'd like to highlight to reviewers

Please focus on:
- The regex match and rewrite logic for `/search` routes.
- Placement of the new routing branch in `vcl_recv` to ensure it does not conflict with existing path-based routing.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-6842]: https://financialtimes.atlassian.net/browse/UPPSF-6842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ