### PR TITLE
UPPSF-7061 Change Varnish Config to recognize content-tree endpoint for invalid UUIDs

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -464,7 +464,7 @@ sub vcl_recv {
     } elif (req.url ~ "^\/content\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal.*$") {
             set req.url = regsub(req.url, "^/content/(.*)$", "/\1");
             set req.backend_hint = enriched_content_read_postgres;
-    } elseif (req.url ~ "\/content-tree\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*$") {
+    } elseif (req.url ~ "\/content-tree\/.*$") {
             set req.backend_hint = cm_content_tree_api;
     }
 


### PR DESCRIPTION
# Description

- currently user sending invalid UUID receives a response 404 Not Found - Path not found with HTML in the response body. But the clients expects JSON.
- allowing the requests to reach the service the clients will receive 400 Bad Request - and the response body would be in JSON format.

## What

- Allow invalid UUIDs like asdfg to reach the service - so the service return proper 400 Bad Request response with JSON body.

## Why

[UPPSF-7061](https://financialtimes.atlassian.net/browse/UPPSF-7061)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to. E.g.

_Would appreciate a second pair of eyes on the test_
_I am not quite sure how this bit works_
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-7061]: https://financialtimes.atlassian.net/browse/UPPSF-7061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ