### PR TITLE
UPPSF-7138 Update regex for enriched-content-read-postgres 

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -461,7 +461,7 @@ sub vcl_recv {
             set req.backend_hint = public_content_relation_api;
     } elif (req.url ~ "^\/ontotext\/suggestions\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/details.*$") {
             set req.backend_hint = concept_suggestions_api;
-    } elif (req.url ~ "^\/content\/(internal($|\?.*)|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal.*)$") {
+    } elif (req.url ~ "^\/content\/(internal($|\?.*)|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal($|\?.*))$") {
             set req.url = regsub(req.url, "^/content/(.*)$", "/\1");
             set req.backend_hint = enriched_content_read_postgres;
     } elseif (req.url ~ "\/content-tree\/.*$") {

--- a/default.vcl
+++ b/default.vcl
@@ -461,7 +461,7 @@ sub vcl_recv {
             set req.backend_hint = public_content_relation_api;
     } elif (req.url ~ "^\/ontotext\/suggestions\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/details.*$") {
             set req.backend_hint = concept_suggestions_api;
-    } elif (req.url ~ "^\/content\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal.*$") {
+    } elif (req.url ~ "^\/content\/(internal($|\?.*)|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\/internal.*)$") {
             set req.url = regsub(req.url, "^/content/(.*)$", "/\1");
             set req.backend_hint = enriched_content_read_postgres;
     } elseif (req.url ~ "\/content-tree\/.*$") {


### PR DESCRIPTION
# Description

## What

This PR updates the delivery varnish routing for `enriched-content-read-postgres`.

`enriched-content-read-postgres` already handled requests routed from:

`/content/{id}/internal`

which delivery varnish rewrites to:

`/{id}/internal`

The service now also supports a new internal endpoint for fetching enriched content for multiple content IDs:

`/internal`

To expose that through delivery varnish, this PR extends the existing enriched-content route check so that varnish also matches:

`/content/internal`

and rewrites it to:

`/internal`

Both routes are handled by the same routing block because they use the same backend and the same rewrite pattern: strip the `/content/` prefix and forward the remaining path to `enriched_content_read_postgres`.

## Why

A corresponding change has been added in `enriched-content-read-postgres` to support batch lookup of enriched content via the new `/internal` endpoint. ( see https://github.com/Financial-Times/enriched-content-read-postgres/pull/14)

Without this varnish change, requests to `/content/internal` would not be routed to `enriched-content-read-postgres`, so clients would not be able to access the new batch endpoint through the delivery varnish entry point.

## Anything, in particular, you'd like to highlight to reviewers

Please check the combined URL regex for the enriched-content routing.

The intention is to preserve the existing behaviour for:

`/content/{id}/internal`

which should still be rewritten to:

`/{id}/internal`

and add support for:

`/content/internal`

which should be rewritten to:

`/internal`

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated