### PR TITLE
UPPSF-7253 do not duplicate Origin in Vary header

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -562,9 +562,9 @@ sub vcl_deliver {
         set resp.http.Access-Control-Allow-Methods = "GET, POST, OPTIONS";
         set resp.http.Access-Control-Allow-Headers = "*";
     }
-    if (resp.http.Vary) {
-        set resp.http.Vary = resp.http.Vary + ",Origin";
-    } else {
+    if (!resp.http.Vary) {
         set resp.http.Vary = "Origin";
+    } else if (resp.http.Vary !~ "(?i)(^|,)[ ]*Origin[ ]*(,|$)") {
+        set resp.http.Vary = resp.http.Vary + ", Origin";
     }
 }


### PR DESCRIPTION
# Description

## What

- Do not duplicate Origin value in the Vary header if it is already present

## Why

[UPPSF-7253](https://financialtimes.atlassian.net/browse/UPPSF-7253)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to. E.g.

_Would appreciate a second pair of eyes on the test_
_I am not quite sure how this bit works_
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-7253]: https://financialtimes.atlassian.net/browse/UPPSF-7253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ